### PR TITLE
fix: handle invalid todo positions gracefully

### DIFF
--- a/tests/test_position_validation.py
+++ b/tests/test_position_validation.py
@@ -1,0 +1,157 @@
+"""
+Tests for position validation in todo-cli.
+Tests that invalid positions are handled gracefully with helpful error messages.
+"""
+
+import os
+import pytest
+from typer.testing import CliRunner
+from todocli.todo import app
+from todocli import database
+
+
+@pytest.fixture(autouse=True)
+def clean_database():
+    """Clean up the database before and after each test."""
+    # Clear all todos from the database
+    database.c.execute("DELETE FROM todos")
+    database.conn.commit()
+    yield
+    # Clean up after test
+    database.c.execute("DELETE FROM todos")
+    database.conn.commit()
+
+
+@pytest.fixture
+def runner():
+    """Create a CLI runner for testing."""
+    return CliRunner()
+
+
+class TestDeleteValidation:
+    """Tests for delete command position validation."""
+
+    def test_delete_empty_database(self, runner):
+        """Test deleting from empty database shows helpful error."""
+        result = runner.invoke(app, ["delete", "1"])
+        assert result.exit_code == 1
+        assert "No todos exist" in result.output
+
+    def test_delete_position_too_high(self, runner):
+        """Test deleting with position higher than total todos."""
+        runner.invoke(app, ["add", "Test task", "study"])
+        result = runner.invoke(app, ["delete", "100"])
+        assert result.exit_code == 1
+        assert "Position 100 does not exist" in result.output
+        assert "Valid positions are 1 to 1" in result.output
+
+    def test_delete_position_zero(self, runner):
+        """Test deleting with position 0 shows error."""
+        runner.invoke(app, ["add", "Test task", "study"])
+        result = runner.invoke(app, ["delete", "0"])
+        assert result.exit_code == 1
+        assert "positive number" in result.output
+
+    def test_delete_valid_position(self, runner):
+        """Test deleting with valid position succeeds."""
+        runner.invoke(app, ["add", "Test task", "study"])
+        result = runner.invoke(app, ["delete", "1"])
+        assert result.exit_code == 0
+
+
+class TestUpdateValidation:
+    """Tests for update command position validation."""
+
+    def test_update_empty_database(self, runner):
+        """Test updating in empty database shows helpful error."""
+        result = runner.invoke(app, ["update", "1", "--task", "New task"])
+        assert result.exit_code == 1
+        assert "No todos exist" in result.output
+
+    def test_update_position_too_high(self, runner):
+        """Test updating with position higher than total todos."""
+        runner.invoke(app, ["add", "Test task", "study"])
+        result = runner.invoke(app, ["update", "50", "--task", "New task"])
+        assert result.exit_code == 1
+        assert "Position 50 does not exist" in result.output
+
+    def test_update_position_zero(self, runner):
+        """Test updating with position 0 shows error."""
+        runner.invoke(app, ["add", "Test task", "study"])
+        result = runner.invoke(app, ["update", "0", "--task", "New task"])
+        assert result.exit_code == 1
+        assert "positive number" in result.output
+
+    def test_update_valid_position(self, runner):
+        """Test updating with valid position succeeds."""
+        runner.invoke(app, ["add", "Test task", "study"])
+        result = runner.invoke(app, ["update", "1", "--task", "Updated task"])
+        assert result.exit_code == 0
+
+
+class TestCompleteValidation:
+    """Tests for complete command position validation."""
+
+    def test_complete_empty_database(self, runner):
+        """Test completing in empty database shows helpful error."""
+        result = runner.invoke(app, ["complete", "1"])
+        assert result.exit_code == 1
+        assert "No todos exist" in result.output
+
+    def test_complete_position_too_high(self, runner):
+        """Test completing with position higher than total todos."""
+        runner.invoke(app, ["add", "Test task", "study"])
+        result = runner.invoke(app, ["complete", "25"])
+        assert result.exit_code == 1
+        assert "Position 25 does not exist" in result.output
+
+    def test_complete_position_zero(self, runner):
+        """Test completing with position 0 shows error."""
+        runner.invoke(app, ["add", "Test task", "study"])
+        result = runner.invoke(app, ["complete", "0"])
+        assert result.exit_code == 1
+        assert "positive number" in result.output
+
+    def test_complete_valid_position(self, runner):
+        """Test completing with valid position succeeds."""
+        runner.invoke(app, ["add", "Test task", "study"])
+        result = runner.invoke(app, ["complete", "1"])
+        assert result.exit_code == 0
+
+
+class TestDatabaseHelpers:
+    """Tests for database helper functions."""
+
+    def test_get_todo_count_empty(self):
+        """Test get_todo_count returns 0 for empty database."""
+        assert database.get_todo_count() == 0
+
+    def test_get_todo_count_with_todos(self, runner):
+        """Test get_todo_count returns correct count."""
+        runner.invoke(app, ["add", "Task 1", "study"])
+        runner.invoke(app, ["add", "Task 2", "work"])
+        assert database.get_todo_count() == 2
+
+    def test_is_valid_position_empty_database(self):
+        """Test is_valid_position returns False for empty database."""
+        assert database.is_valid_position(0) is False
+        assert database.is_valid_position(1) is False
+
+    def test_is_valid_position_negative(self, runner):
+        """Test is_valid_position returns False for negative position."""
+        runner.invoke(app, ["add", "Task", "study"])
+        assert database.is_valid_position(-1) is False
+
+    def test_is_valid_position_valid(self, runner):
+        """Test is_valid_position returns True for valid position."""
+        runner.invoke(app, ["add", "Task", "study"])
+        assert database.is_valid_position(0) is True  # 0-indexed
+
+    def test_is_valid_position_too_high(self, runner):
+        """Test is_valid_position returns False for position >= count."""
+        runner.invoke(app, ["add", "Task", "study"])
+        assert database.is_valid_position(1) is False  # 0-indexed, only 0 is valid
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/todocli/database.py
+++ b/todocli/database.py
@@ -52,7 +52,29 @@ def get_all_todos() -> List[Todo]:
     for row in rows:
         todos.append(Todo(*row))
 
-    return todos   
+    return todos
+
+
+def get_todo_count() -> int:
+    """Returns the total number of todos in the database."""
+    c.execute("SELECT COUNT(*) FROM todos")
+    return c.fetchone()[0]
+
+
+def is_valid_position(position: int) -> bool:
+    """
+    Check if a position is valid (exists in the database).
+
+    Args:
+        position: The 0-indexed position to check.
+
+    Returns:
+        True if the position exists, False otherwise.
+    """
+    if position < 0:
+        return False
+    count = get_todo_count()
+    return position < count   
 
 
 def delete_todo(position: int):

--- a/todocli/todo.py
+++ b/todocli/todo.py
@@ -2,11 +2,48 @@ import typer
 from rich.console import Console
 from rich.table import Table
 from .model import Todo
-from .database import get_all_todos, delete_todo, insert_todo, complete_todo, update_todo
+from .database import (
+    get_all_todos,
+    delete_todo,
+    insert_todo,
+    complete_todo,
+    update_todo,
+    is_valid_position,
+    get_todo_count,
+)
 
 console = Console()
 
 app = typer.Typer()
+
+
+def validate_position(position: int) -> bool:
+    """
+    Validate that a position is valid (exists in the todo list).
+
+    Args:
+        position: The 1-indexed position provided by the user.
+
+    Returns:
+        True if valid, raises typer.Exit if invalid.
+    """
+    total_count = get_todo_count()
+
+    if total_count == 0:
+        console.print("[bold red]Error:[/bold red] No todos exist. Add a todo first using 'add'.")
+        raise typer.Exit(code=1)
+
+    if position < 1:
+        console.print(f"[bold red]Error:[/bold red] Position must be a positive number (1 or greater).")
+        console.print(f"[yellow]Hint:[/yellow] Valid positions are 1 to {total_count}.")
+        raise typer.Exit(code=1)
+
+    if position > total_count:
+        console.print(f"[bold red]Error:[/bold red] Position {position} does not exist.")
+        console.print(f"[yellow]Hint:[/yellow] You only have {total_count} todo(s). Valid positions are 1 to {total_count}.")
+        raise typer.Exit(code=1)
+
+    return True
 
 
 @app.command(short_help='adds an item')
@@ -15,27 +52,29 @@ def add(task: str, category: str):
     todo = Todo(task, category)
     insert_todo(todo)
     show()
-    
-    
+
+
 @app.command()
 def delete(position: int):
+    validate_position(position)
     typer.echo(f"deleting {position}")
-    delete_todo(position-1)
+    delete_todo(position - 1)
     show()
-    
-    
-    
+
+
 @app.command()
 def update(position: int, task: str = None, category: str = None):
+    validate_position(position)
     typer.echo(f"updating {position}")
-    update_todo(position-1,task,category)
+    update_todo(position - 1, task, category)
     show()
-    
-    
+
+
 @app.command()
-def complete(position: int,):
+def complete(position: int):
+    validate_position(position)
     typer.echo(f"complete {position}")
-    complete_todo(position-1)
+    complete_todo(position - 1)
     show()
     
 @app.command()


### PR DESCRIPTION
## Summary

This PR addresses Issue #1 by implementing proper validation for todo positions in delete, update, and complete commands.

### Changes

**Database module (`todocli/database.py`):**
- Added `get_todo_count()` to get total number of todos
- Added `is_valid_position()` to validate 0-indexed positions

**CLI module (`todocli/todo.py`):**
- Added `validate_position()` helper function that checks:
  - Empty database: Shows "No todos exist. Add a todo first using 'add'."
  - Position < 1: Shows "Position must be a positive number (1 or greater)."
  - Position > total: Shows "Position X does not exist. You only have Y todo(s)."
- Applied validation to `delete`, `update`, and `complete` commands
- Commands now exit with code 1 on validation errors

### Example outputs

```
# Empty database
$ todo delete 1
Error: No todos exist. Add a todo first using 'add'.

# Position too high
$ todo delete 100
Error: Position 100 does not exist.
Hint: You only have 3 todo(s). Valid positions are 1 to 3.

# Position 0 or negative
$ todo delete 0
Error: Position must be a positive number (1 or greater).
Hint: Valid positions are 1 to 3.
```

## Test plan

- [x] Added 18 test cases covering all validation scenarios
- [x] All tests pass
- [x] Manual testing with various invalid inputs

Closes #1

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>